### PR TITLE
add extra_fields in ensure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.3.1]
+### Fixed
+- Ensure that `Honeykiq::ServerMiddleware#extra_fields` are still included after a job fails
 
 ## [0.3.0]
 ### Added
@@ -17,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `Honeykiq.periodic_reporter`. (Use `Honeykiq::PeriodicReporter.new` instead.)
 
-[Unreleased]: https://github.com/carwow/honeykiq/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/carwow/honeykiq/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/carwow/honeykiq/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/carwow/honeykiq/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/carwow/honeykiq/compare/v0.1.0...v0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    honeykiq (0.3.0)
+    honeykiq (0.3.1)
       sidekiq
 
 GEM

--- a/lib/honeykiq/version.rb
+++ b/lib/honeykiq/version.rb
@@ -1,3 +1,3 @@
 module Honeykiq
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/honeykiq/server_middleware_spec.rb
+++ b/spec/honeykiq/server_middleware_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Honeykiq::ServerMiddleware do
   context 'on error' do
     let(:expected_event_for_error) do
       expected_event.merge(
-        'job.arguments_bytes': 8,
+        'job.arguments_bytes': instance_of(Integer),
         'job.status': 'failed',
         'error.class': TestSidekiqWorker::Error.to_s,
         'error.message': 'BOOM'
@@ -103,6 +103,17 @@ RSpec.describe Honeykiq::ServerMiddleware do
     it 'sends an event with expected values' do
       perform do
         expect(honey_client.events.first.data).to include(expected_event_for_error)
+      end
+    end
+
+    describe 'adding `extra_fields`' do
+      let(:test_class) { TestExtraFields }
+      let(:expected_user_event) { expected_event_for_error.merge(extra_data_item: 'foo') }
+
+      it 'adds the extra keys' do
+        perform do
+          expect(honey_client.events.first.data).to include(expected_user_event)
+        end
       end
     end
   end


### PR DESCRIPTION
### [0.3.1]
#### Fixed
- Ensure that `Honeykiq::ServerMiddleware#extra_fields` are still included after a job fails