### PR TITLE
Use CLOCK_MONOTONIC for duration_ms

### DIFF
--- a/lib/honeykiq/server_middleware.rb
+++ b/lib/honeykiq/server_middleware.rb
@@ -78,10 +78,10 @@ module Honeykiq
     end
 
     def duration_ms(event)
-      start_time = Time.now
+      start_time = now
       yield
     ensure
-      duration = Time.now - start_time
+      duration = now - start_time
       event.add_field(:duration_ms, duration * 1000)
     end
 
@@ -95,6 +95,16 @@ module Honeykiq
         'error.class': error.class.name,
         'error.message': error.message
       )
+    end
+
+    if defined?(Process::CLOCK_MONOTONIC)
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def now
+        Time.now
+      end
     end
   end
 end


### PR DESCRIPTION
Uses the processes monotonic clock to measure elapsed time, if available.