### PR TITLE
Add tracing links when beeline is configured

### DIFF
--- a/lib/honeykiq.rb
+++ b/lib/honeykiq.rb
@@ -2,4 +2,7 @@ module Honeykiq
   autoload :Version, 'honeykiq/version'
   autoload :PeriodicReporter, 'honeykiq/periodic_reporter'
   autoload :ServerMiddleware, 'honeykiq/server_middleware'
+  autoload :ClientMiddleware, 'honeykiq/client_middleware'
+  autoload :BeelineSpan, 'honeykiq/beeline_span'
+  autoload :LibhoneySpan, 'honeykiq/libhoney_span'
 end

--- a/lib/honeykiq/beeline_span.rb
+++ b/lib/honeykiq/beeline_span.rb
@@ -1,0 +1,54 @@
+module Honeykiq
+  class BeelineSpan
+    def initialize(tracing_mode)
+      @tracing_mode = tracing_mode
+    end
+
+    def call(name:, serialized_trace:, &block)
+      case tracing_mode
+      when :link  then link_span(name, serialized_trace, &block)
+      when :child then child_span(name, serialized_trace, &block)
+      else
+        Honeycomb.start_span(name: name, &block)
+      end
+    end
+
+    private
+
+    attr_reader :tracing_mode
+
+    def link_span(name, serialized_trace)
+      Honeycomb.start_span(name: name) do |event|
+        link_to_enqueuing_trace(event, serialized_trace)
+
+        yield event
+      end
+    end
+
+    def child_span(name, serialized_trace)
+      Honeycomb.start_span(name: name, serialized_trace: serialized_trace) do |event|
+        yield event
+      end
+    end
+
+    def link_to_enqueuing_trace(current, serialized_trace)
+      return unless serialized_trace
+
+      trace_id, parent_span_id, = TraceParser.parse(serialized_trace)
+
+      Honeycomb.libhoney.event.add(
+        'trace.link.trace_id': trace_id,
+        'trace.link.span_id': parent_span_id,
+        'meta.span_type': 'link',
+        'trace.parent_id': current.id,
+        'trace.trace_id': current.trace.id
+      ).send
+    end
+
+    if defined?(Honeycomb)
+      class TraceParser
+        extend Honeycomb::PropagationParser
+      end
+    end
+  end
+end

--- a/lib/honeykiq/client_middleware.rb
+++ b/lib/honeykiq/client_middleware.rb
@@ -1,0 +1,9 @@
+module Honeykiq
+  class ClientMiddleware
+    def call(_, job, _, _)
+      job['serialized_trace'] = Honeycomb.current_span&.to_trace_header
+
+      yield
+    end
+  end
+end

--- a/lib/honeykiq/libhoney_span.rb
+++ b/lib/honeykiq/libhoney_span.rb
@@ -1,0 +1,37 @@
+module Honeykiq
+  class LibhoneySpan
+    def initialize(libhoney)
+      @libhoney = libhoney
+    end
+
+    def call(*)
+      libhoney.event.tap do |event|
+        duration_ms(event) { yield event }
+      ensure
+        event.send
+      end
+    end
+
+    private
+
+    attr_reader :libhoney
+
+    def duration_ms(event)
+      start_time = now
+      yield
+    ensure
+      duration = now - start_time
+      event.add_field(:duration_ms, duration * 1000)
+    end
+
+    if defined?(Process::CLOCK_MONOTONIC)
+      def now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+    else
+      def now
+        Time.now
+      end
+    end
+  end
+end

--- a/spec/honeykiq/client_middleware_spec.rb
+++ b/spec/honeykiq/client_middleware_spec.rb
@@ -1,0 +1,54 @@
+require 'honeycomb-beeline'
+require 'sidekiq/testing'
+
+class TestSidekiqWorker
+  include Sidekiq::Worker
+
+  def perform; end
+end
+
+RSpec.describe Honeykiq::ClientMiddleware do
+  let(:libhoney) { Libhoney::TestClient.new }
+
+  before do
+    Sidekiq::Worker.clear_all
+    Sidekiq::Testing.fake!
+
+    Honeycomb.configure do |config|
+      config.client = libhoney
+    end
+
+    Sidekiq.configure_client do |config|
+      config.client_middleware do |chain|
+        chain.clear
+        chain.add described_class
+      end
+    end
+  end
+
+  context 'when within a span' do
+    it 'adds serialized_trace to the job' do
+      expected_span = nil
+
+      Honeycomb.start_span(name: 'test') do |span|
+        expected_span = span
+
+        TestSidekiqWorker.perform_async
+      end
+
+      job = TestSidekiqWorker.jobs.first
+
+      expect(job['serialized_trace']).to eq(expected_span.to_trace_header)
+    end
+  end
+
+  context 'when not within a span' do
+    it 'does not set serialized_trace' do
+      TestSidekiqWorker.perform_async
+
+      job = TestSidekiqWorker.jobs.first
+
+      expect(job['serialized_trace']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Adds tracing fields via the `beeline` if available.
- Adds an additional `ClientMiddleware` to forward the `Honeycomb.current_span` using `#to_trace_header` as `serialized_trace`
- Updates `ServerMiddleware` to send [a link event](https://docs.honeycomb.io/working-with-your-data/tracing/send-trace-data/#links) using to link the new span to the `serialized_trace`.
For us internally there should be no impact on our tracing setup because we don't use the beeline!

<img width="1552" alt="Screenshot 2020-06-10 at 20 40 42" src="https://user-images.githubusercontent.com/7707413/84311131-b036a900-ab5a-11ea-8b74-f7b243407f70.png">
