### PR TITLE
Delete contributors.txt

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,0 @@
-Pedro Chambino <pedro.chambino@carwow.co.uk>
-Dan Rees-Jones <dan.reesjones@carwow.co.uk>
-Christian Gregg <christian.gregg@carwow.co.uk>

--- a/README.md
+++ b/README.md
@@ -117,18 +117,15 @@ module Clockwork
 end
 ```
 
+[clockwork]: https://github.com/Rykian/clockwork
+
 ## Contributing
 
 [Pull requests](https://github.com/carwow/honeykiq/pulls) are very welcome!
-Don't forget to add yourself to [CONTRIBUTORS.txt].
 
 Please report bugs in a [new issue](https://github.com/carwow/honeykiq/issues/new).
-
-[CONTRIBUTORS.txt]: https://github.com/carwow/honeykiq/blob/master/CONTRIBUTORS.txt
 
 ## License
 
 The gem is available as open source under the terms of the
 [MIT License](https://opensource.org/licenses/MIT).
-
-[clockwork]: https://github.com/Rykian/clockwork


### PR DESCRIPTION
Git and GitHub already provide this out of the box no need to implement a manual one.

(I initially thought this was a contributing.md file.)