### PR TITLE
Allow sending extra arbitrary job fields

### DIFF
--- a/lib/honeykiq/server_middleware.rb
+++ b/lib/honeykiq/server_middleware.rb
@@ -47,7 +47,17 @@ module Honeykiq
       on_error(event, error)
       raise
     ensure
+      send_job_fields(event, job)
       event.add(extra_fields)
+    end
+
+    def send_job_fields(event, job)
+      job_const = Object.const_get(job.value['class'])
+      return unless job_const.respond_to?(:extra_fields)
+
+      job_extra_fields = job_const.send(:extra_fields, job)
+
+      event.add(job_extra_fields)
     end
 
     def default_fields(job, queue)


### PR DESCRIPTION
Call job class method `.extra_fields` (if it exists) to generate relevant span metadata from original job arguments.

This is useful to generate a high-cardinality event using the original arguments passed to the job. As opposed to the naïve implementation, in #14, this allows the consumer of this library to opt-in to this behavior and select only the relevant data to send to Honeycomb.