### PR TITLE
Allow extra_fields to be invoked with job

### DIFF
--- a/lib/honeykiq/server_middleware.rb
+++ b/lib/honeykiq/server_middleware.rb
@@ -15,15 +15,9 @@ module Honeykiq
       end
     end
 
-    def extra_fields
+    def extra_fields(_job = nil)
       {}
     end
-
-    # rubocop:disable Lint/UnusedMethodArgument
-    def extra_job_fields(job = nil)
-      {}
-    end
-    # rubocop:enable Lint/UnusedMethodArgument
 
     private
 
@@ -53,8 +47,7 @@ module Honeykiq
       on_error(event, error)
       raise
     ensure
-      event.add(extra_fields)
-      event.add(extra_job_fields(job))
+      event.add(call_extra_fields(job))
     end
 
     def default_fields(job, queue)
@@ -102,6 +95,13 @@ module Honeykiq
         'error.class': error.class.name,
         'error.message': error.message
       )
+    end
+
+    def call_extra_fields(job)
+      case method(:extra_fields).arity
+      when 0 then extra_fields
+      else extra_fields(job)
+      end
     end
 
     if defined?(Process::CLOCK_MONOTONIC)

--- a/lib/honeykiq/server_middleware.rb
+++ b/lib/honeykiq/server_middleware.rb
@@ -19,6 +19,12 @@ module Honeykiq
       {}
     end
 
+    # rubocop:disable Lint/UnusedMethodArgument
+    def extra_job_fields(job = nil)
+      {}
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
     private
 
     attr_reader :libhoney
@@ -48,6 +54,7 @@ module Honeykiq
       raise
     ensure
       event.add(extra_fields)
+      event.add(extra_job_fields(job))
     end
 
     def default_fields(job, queue)

--- a/spec/honeykiq/server_middleware_spec.rb
+++ b/spec/honeykiq/server_middleware_spec.rb
@@ -18,7 +18,7 @@ class TestExtraFields < Honeykiq::ServerMiddleware
 end
 
 class TestExtraJobFields < Honeykiq::ServerMiddleware
-  def extra_job_fields(job)
+  def extra_fields(job)
     { 'job.arguments': job.args }
   end
 end


### PR DESCRIPTION
Follow up to @faun PRs and suggestions (see [link](https://github.com/carwow/honeykiq/pull/14#issuecomment-664643621))

Passing the Sidekiq job to `extra_fields` allows to include more fields in the event with data from the Sidekiq job, e.g. the job arguments.

```ruby
class CustomHoneykiqMiddleware < Honeykiq::ServerMiddleware
  def extra_fields(job)
    { 'job.arguments': job.args }
  end
end
```