### PR TITLE
 Child trace tracing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Sidekiq.configure_server do |config|
     # - :child starts a span as a child of the enqueuing trace,
     #   requires ClientMiddleware to be configured when enqueuing the job.
     #
+    # - :child_trace (experimental) starts a span and a trace
+    #   with trace.parent_id set to the enqueuing trace id,
+    #   requires ClientMiddleware to be configured when enqueuing the job.
+    #
     # - :link (experimental) starts a span and trace
     #   with a link event that points to the enqueuing trace,
     #   requires ClientMiddleware to be configured when enqueuing the job.

--- a/example/server.rb
+++ b/example/server.rb
@@ -27,6 +27,10 @@ Sidekiq.configure_server do |config|
     # - :child starts a span as a child of the enqueuing trace,
     #   requires ClientMiddleware to be configured when enqueuing the job.
     #
+    # - :child_trace (experimental) starts a span and a trace
+    #   with trace.parent_id set to the enqueuing trace id,
+    #   requires ClientMiddleware to be configured when enqueuing the job.
+    #
     # - :link (experimental) starts a span and trace
     #   with a link event that points to the enqueuing trace,
     #   requires ClientMiddleware to be configured when enqueuing the job.


### PR DESCRIPTION
Start a span and trace when the job executes with a reference to the enqueuing trace in the field `parent.trace_id`.