### PR TITLE
Support Sidekiq 8

### DIFF
--- a/honeykiq.gemspec
+++ b/honeykiq.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "sidekiq", ">= 6.2.2", "<8"
+  spec.add_dependency "sidekiq", ">= 6.2.2", "<9"
 
   spec.add_development_dependency "honeycomb-beeline", "~> 2"
   spec.add_development_dependency "pry", "~> 0.14"


### PR DESCRIPTION
## Summary
- Updated gemspec to support Sidekiq 8.x
- Changed version constraint from `<8` to `<9` to allow Sidekiq 8 compatibility
- All existing tests pass with Sidekiq 8.0.7

## Test plan
- [x] Run test suite with Sidekiq 8.0.7
- [x] Verify no breaking changes affect the codebase
- [x] Confirm JobRecord API compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)